### PR TITLE
create dasharrays that divide evenly on desktop

### DIFF
--- a/assets/styles/layouts/_global.scss
+++ b/assets/styles/layouts/_global.scss
@@ -14,28 +14,28 @@ html {
 .face--day {
     stroke-width: 1px;
     stroke: #000;
-    stroke-dasharray: 1, 5%;
+    stroke-dasharray: calc(250px/60);
     fill: #c0ffee;
 }
 
 .face--hour {
     stroke-width: 1px;
     stroke: #000;
-    stroke-dasharray: 1, 10.8%;
+    stroke-dasharray: calc(250px/48);
     fill: #c0ffee;
 }
 
 .face--min {
     stroke-width: 1px;
     stroke: #000;
-    stroke-dasharray: 1, 3.16%;
+    stroke-dasharray: calc(250px/120);
     fill: #c0ffee;
 }
 
 .face--sec {
     stroke-width: 1px;
     stroke: #000;
-    stroke-dasharray: 1, 3.16%;
+    stroke-dasharray: calc(250px/120);
     fill: #c0ffee;
 }
 


### PR DESCRIPTION
Closes #16. Note: just a temporary fix, as the ideal is to have the outside look more like `•  •  •` than `–  –  –`.

@singram26 please review!
